### PR TITLE
Added configuration option g:vebugger_edit_cmd

### DIFF
--- a/autoload/vebugger/std.vim
+++ b/autoload/vebugger/std.vim
@@ -169,7 +169,7 @@ function! s:standardThinkHandlers.moveToCurrentLine(readResult,debugger) dict
 			endif
 			let a:debugger.state.std.location=deepcopy(a:readResult.std.location)
 			if !bufexists(a:readResult.std.location.file)
-				exe 'new '.(a:readResult.std.location.file)
+				exe get(g:, 'vebugger_view_source_cmd', 'new').' '.(a:readResult.std.location.file)
 			endif
 			call vebugger#std#updateMarksForFile(a:debugger.state,a:readResult.std.location.file)
 			exe 'sign jump 1 file='.fnameescape(fnamemodify(a:readResult.std.location.file,':p'))

--- a/doc/vebugger.txt
+++ b/doc/vebugger.txt
@@ -94,6 +94,13 @@ argument is supplied when running the debugger:
 *g:vebugger_path_mdbg_32*  No default - use it for the 32bit version of Mdbg
 *g:vebugger_path_mdbg_64*  No default - use it for the 64bit version of Mdbg
 
+When stepping into functions in unopened files, they are opened with :new by
+default. This can be configured by setting *g:vebugger_view_source_cmd*
+
+Example: >
+    let g:vebugger_view_source_cmd='edit'
+<
+
 LAUNCHING DEBUGGERS                                      *vebugger-launching*
 
 A debugger's implementation is responsible for starting it. The standard is to


### PR DESCRIPTION
This enables the user to configure how source files should be opened (new, vnew, edit, etc.).
