### PR TITLE
Added support for repeat.vim.

### DIFF
--- a/plugin/vebugger.vim
+++ b/plugin/vebugger.vim
@@ -1,25 +1,34 @@
 
+function! s:recordCall(...)
+	let l:func=a:1
+	let l:args=a:000[1:]
+	call call(l:func,l:args)
 
-command! -nargs=1 VBGrawWrite call vebugger#writeLine(<q-args>)
+	if(exists('*VBGpostcmd'))
+		call VBGpostcmd(l:func,l:args)
+	endif
+endfunction
+
+command! -nargs=1 VBGrawWrite call s:recordCall('vebugger#writeLine',<q-args>)
 command! -nargs=0 VBGkill call vebugger#killDebugger()
 
-command! -nargs=0 VBGstepIn call vebugger#setWriteActionAndPerform('std','flow','stepin')
-command! -nargs=0 VBGstepOver call vebugger#setWriteActionAndPerform('std','flow','stepover')
-command! -nargs=0 VBGstepOut call vebugger#setWriteActionAndPerform('std','flow','stepout')
-command! -nargs=0 VBGcontinue call vebugger#setWriteActionAndPerform('std','flow','continue')
+command! -nargs=0 VBGstepIn call s:recordCall('vebugger#setWriteActionAndPerform','std','flow','stepin')
+command! -nargs=0 VBGstepOver call s:recordCall('vebugger#setWriteActionAndPerform','std','flow','stepover')
+command! -nargs=0 VBGstepOut call s:recordCall('vebugger#setWriteActionAndPerform','std','flow','stepout')
+command! -nargs=0 VBGcontinue call s:recordCall('vebugger#setWriteActionAndPerform','std','flow','continue')
 
 command! -nargs=0 VBGtoggleTerminalBuffer call vebugger#toggleTerminalBuffer()
 command! -nargs=+ -complete=file VBGtoggleBreakpoint call vebugger#std#toggleBreakpoint(<f-args>)
-command! -nargs=0 VBGtoggleBreakpointThisLine call vebugger#std#toggleBreakpoint(expand('%:~:.'),line('.'))
+command! -nargs=0 VBGtoggleBreakpointThisLine call s:recordCall('vebugger#std#toggleBreakpoint', expand('%:~:.'),line('.'))
 command! -nargs=0 VBGclearBreakpints call vebugger#std#clearBreakpoints()
 
-command! -nargs=1 VBGeval call vebugger#std#eval(<q-args>)
-command! -nargs=0 VBGevalWordUnderCursor call vebugger#std#eval(expand('<cword>'))
-command! -nargs=1 VBGexecute call vebugger#std#execute(<q-args>)
+command! -nargs=1 VBGeval call s:recordCall('vebugger#std#eval',<q-args>)
+command! -nargs=0 VBGevalWordUnderCursor call s:recordCall('vebugger#std#eval',expand('<cword>'))
+command! -nargs=1 VBGexecute call s:recordCall('vebugger#std#execute',<q-args>)
 
-command! -range -nargs=0 VBGevalSelectedText call vebugger#std#eval(vebugger#util#get_visual_selection())
-command! -range -nargs=0 VBGexecuteSelectedText call vebugger#std#execute(vebugger#util#get_visual_selection())
-command! -range -nargs=0 VBGrawWriteSelectedText call vebugger#writeLine(vebugger#util#get_visual_selection())
+command! -range -nargs=0 VBGevalSelectedText call s:recordCall('vebugger#std#eval',vebugger#util#get_visual_selection())
+command! -range -nargs=0 VBGexecuteSelectedText call s:recordCall('vebugger#std#execute',vebugger#util#get_visual_selection())
+command! -range -nargs=0 VBGrawWriteSelectedText call s:recordCall('vebugger#writeLine',vebugger#util#get_visual_selection())
 
 command! -nargs=+ -complete=file VBGstartGDB call vebugger#gdb#start([<f-args>][0],{'args':[<f-args>][1:]})
 command! -nargs=1 -complete=file VBGattachGDB call vebugger#gdb#searchAndAttach(<q-args>)


### PR DESCRIPTION
This patch allows stepping in, etc. to be repeated using the '.' key.
It adds a dependency on tpope's repeat.vim. (Detecting if it is available is non-trivial as it is autoloaded, so making it optional is somewhat tricky.) I suspect most people who are interested in using vim-vebugger probably have it installed already anyway, so it probably doesn't matter too much.
