### PR TITLE
Release 1.3

### DIFF
--- a/autoload/vebugger/jdb.vim
+++ b/autoload/vebugger/jdb.vim
@@ -1,6 +1,12 @@
-function! vebugger#jdb#start(entryClass,args)
+function! vebugger#jdb#start(args)
+  if !has_key(a:args, 'con')
+    let a:args.con = 9009
+  endif
+
 	let l:debugger=vebugger#std#startDebugger(shellescape(vebugger#util#getToolFullPath('jdb',get(a:args,'version'),'jdb'))
-				\.(has_key(a:args,'classpath') ? ' -classpath '.fnameescape(a:args.classpath) : ''))
+				\.(has_key(a:args,'classpath') ? ' -classpath '.fnameescape(a:args.classpath) : '')
+				\.(!has_key(a:args,'entryClass') ? ' -attach '.fnameescape(a:args.con) : ''))
+
 	let l:debugger.state.jdb={}
 	if has_key(a:args,'srcpath')
 		let l:debugger.state.jdb.srcpath=a:args.srcpath
@@ -9,11 +15,13 @@ function! vebugger#jdb#start(entryClass,args)
 	endif
 	let l:debugger.state.jdb.filesToClassesMap={}
 
-	call l:debugger.writeLine('stop on '.a:entryClass.'.main')
-	call l:debugger.writeLine('run  '.a:entryClass.' '.vebugger#util#commandLineArgsForProgram(a:args))
-	call l:debugger.writeLine('monitor where')
-	if !has('win32')
-		call vebugger#std#openShellBuffer(l:debugger)
+  if has_key(a:args, 'entryClass')
+		if !has('win32')
+			call vebugger#std#openShellBuffer(l:debugger)
+		endif
+		call l:debugger.writeLine('stop on '.a:args.entryClass.'.main')
+		call l:debugger.writeLine('run  '.a:args.entryClass.' '.vebugger#util#commandLineArgsForProgram(a:args))
+		call l:debugger.writeLine('monitor where')
 	endif
 
 	call l:debugger.addReadHandler(function('vebugger#jdb#_readProgramOutput'))

--- a/autoload/vebugger/jdb.vim
+++ b/autoload/vebugger/jdb.vim
@@ -1,7 +1,7 @@
 function! vebugger#jdb#start(args)
-  if !has_key(a:args, 'con')
-    let a:args.con = 9009
-  endif
+	if !has_key(a:args, 'con')
+		let a:args.con = 9009
+	endif
 
 	let l:debugger=vebugger#std#startDebugger(shellescape(vebugger#util#getToolFullPath('jdb',get(a:args,'version'),'jdb'))
 				\.(has_key(a:args,'classpath') ? ' -classpath '.fnameescape(a:args.classpath) : '')
@@ -15,7 +15,7 @@ function! vebugger#jdb#start(args)
 	endif
 	let l:debugger.state.jdb.filesToClassesMap={}
 
-  if has_key(a:args, 'entryClass')
+	if has_key(a:args, 'entryClass')
 		if !has('win32')
 			call vebugger#std#openShellBuffer(l:debugger)
 		endif

--- a/doc/vebugger.txt
+++ b/doc/vebugger.txt
@@ -137,22 +137,26 @@ LAUNCHING JDB                                                 *vebugger-jdb*
 
 JDB is launched with *vebugger#jdb#start*
 >
-    call vebugger#jdb#start('Main',{
+    call vebugger#jdb#start({
+        \'entryClass':'Main',
         \'classpath':'classes',
         \'srcpath':'src',
         \'args':['hello','world']})
 <
-Unlike in the other debuggers, the first argument here is not the name of a
-file - it's the name of the class to run. The supported extra arguments are:
+Unlike in the other debuggers, there is no first argument. The supported extra arguments are:
 * "args": Command line arguments for the debugged program
 * "classpath": Where to look for class files
 * "srcpath": Where to look for source files
 * "version": The version of the debugger to run
+* "con": A connection string for attaching to an existing jvm. Ex. localhost:8000 or 8000
+  defaults to 9009, the standard debug port for jvms.
+* "entryClass": A class that contains main for starting the jdb up with.
+If entryClass is defined it takes precedence over con.
 If you don't supply "classpath" and "srcpath", Vebugger will assume you are
 using the current directory for source files and class files.
 
-JDB does not have a command for starting it, since you usually want to supply
-"classpath" and "srcpath".
+JDB can be started with VBGattachJDB. If the desired the user can call the command with the extra
+arguments that are defined above.
 
 
 LAUNCHING RDEBUG                                             *vebugger-rdebug*

--- a/doc/vebugger.txt
+++ b/doc/vebugger.txt
@@ -155,7 +155,7 @@ If entryClass is defined it takes precedence over con.
 If you don't supply "classpath" and "srcpath", Vebugger will assume you are
 using the current directory for source files and class files.
 
-JDB can be started with VBGattachJDB. If the desired the user can call the command with the extra
+JDB can be started with VBGstartJDB. If the desired the user can call the command with the extra
 arguments that are defined above.
 
 

--- a/plugin/vebugger.vim
+++ b/plugin/vebugger.vim
@@ -28,6 +28,7 @@ command! -nargs=+ -complete=file VBGstartPDB call vebugger#pdb#start([<f-args>][
 command! -nargs=+ -complete=file VBGstartPDB2 call vebugger#pdb#start([<f-args>][0],{'args':[<f-args>][1:],'version':'2'})
 command! -nargs=+ -complete=file VBGstartPDB3 call vebugger#pdb#start([<f-args>][0],{'args':[<f-args>][1:],'version':'3'})
 command! -nargs=+ -complete=file VBGstartGDBForD call vebugger#gdb#start([<f-args>][0],{'args':[<f-args>][1:],'entry':'_Dmain'})
+command! -nargs=* -complete=command VBGattachJDB call vebugger#jdb#start(string(<q-args>) ? eval([<f-args>][0]) : {})
 
 if exists('g:vebugger_leader')
 	if !empty(g:vebugger_leader)

--- a/plugin/vebugger.vim
+++ b/plugin/vebugger.vim
@@ -28,7 +28,7 @@ command! -nargs=+ -complete=file VBGstartPDB call vebugger#pdb#start([<f-args>][
 command! -nargs=+ -complete=file VBGstartPDB2 call vebugger#pdb#start([<f-args>][0],{'args':[<f-args>][1:],'version':'2'})
 command! -nargs=+ -complete=file VBGstartPDB3 call vebugger#pdb#start([<f-args>][0],{'args':[<f-args>][1:],'version':'3'})
 command! -nargs=+ -complete=file VBGstartGDBForD call vebugger#gdb#start([<f-args>][0],{'args':[<f-args>][1:],'entry':'_Dmain'})
-command! -nargs=* -complete=command VBGattachJDB call vebugger#jdb#start(string(<q-args>) ? eval([<f-args>][0]) : {})
+command! -nargs=* -complete=command VBGstartJDB call vebugger#jdb#start(string(<q-args>) ? eval([<f-args>][0]) : {})
 
 if exists('g:vebugger_leader')
 	if !empty(g:vebugger_leader)


### PR DESCRIPTION
### Task list
- [x] limit to one start
- [x] update the documentation for JDB
- [x] create a issue closing commit
### The approach

Okay I deviated a bit from our discussion. Hopefully you're cool with the approach. If not I can change it...

So here goes. I went with the single startup. However, I converted the first argument to be a optional in the args dictionary. Here are my reasons:
- Dictionary approach is powerful in that it lends flexibility. Why not do that for the first argument? I understand for other debuggers like gdb you have supply the binary to get at debug symbols. In java you don't have too. Does it really have to have consistency across all start calls? I really like to avoid passing blank string or something falsey as the first argument.
- If the entryClass is defined in the dictionary, I have that take precedence. 
- Having the only argument be the dictionary, requires erroring out or reasonable defaults. For JDB I feel that the reasonable defaults would be having con set to 9009 (the standard jvm debug port). It would be cool to maybe default the entryClass if your current buffer contains main. 
- This affords a simple startup with the command VBGstartJDB
- VBGstartJDB was made to work with or without arguments.
### If changset is adopted, what issues I'd create
1. It would be cool to have some feedback that you are attached or not. Going bufferless when attached makes sense, but you then lack any signal that you are attached or not. 
2. Seems like the file being edited in the buffers and the package definition could be used to create the srcpath. 
3. Create test scripts via http://linux.die.net/man/1/expect scripts

Let me know what you think!
