### PR TITLE
Fix typo & Close shell buffer when killing the debugger

### DIFF
--- a/autoload/vebugger.vim
+++ b/autoload/vebugger.vim
@@ -289,6 +289,7 @@ function! vebugger#killDebugger()
         autocmd!
     augroup END
     if exists('s:debugger')
+        call vebugger#std#closeShellBuffer(s:debugger)
         call s:debugger.closeTerminalBuffer()
         call s:debugger.kill()
         unlet s:debugger

--- a/autoload/vebugger/std.vim
+++ b/autoload/vebugger/std.vim
@@ -101,6 +101,18 @@ function! vebugger#std#openShellBuffer(debugger)
     wincmd p
 endfunction
 
+"Closes the shell buffer
+function! vebugger#std#closeShellBuffer(debugger)
+    if has_key(a:debugger,'shellBuffer')
+        if -1<bufwinnr(a:debugger.shellBuffer)
+            let l:bufwin=bufwinnr(a:debugger.shellBuffer)
+            exe l:bufwin.'wincmd w'
+            wincmd c
+            wincmd p
+        endif
+    endif
+endfunction
+
 let s:standardFunctions={}
 
 "Write a line to the shell buffer

--- a/doc/vebugger.txt
+++ b/doc/vebugger.txt
@@ -253,7 +253,7 @@ MANAGE BREAKPOINTS                                      *vebugger-breakpoints*
 
 *:VBGtoggleBreakpoint* Toggle a breakpoint. The file and line should be supplied as arguments.
 *:VBGtoggleBreakpointThisLine* Toggle a breakpoint for the current line.
-*:VBGclearBreakpints* Clear all breakpoints.
+*:VBGclearBreakpoints* Clear all breakpoints.
 
 EVALUATE EXPRESSIONS                                      *vebugger-evalutate*
 
@@ -294,7 +294,7 @@ O      |:VBGstepOut|
 c      |:VBGcontinue|
 
 b      |:VBGtoggleBreakpointThisLine|
-B      |:VBGclearBreakpints|
+B      |:VBGclearBreakpoints|
 
 e      |:VBGevalWordUnderCursor| in normal mode
        |:VBGevalSelectedText| in select mode

--- a/plugin/vebugger.vim
+++ b/plugin/vebugger.vim
@@ -13,7 +13,7 @@ command! -nargs=0 VBGcontinue call vebugger#userAction('setWriteActionAndPerform
 command! -nargs=0 VBGtoggleTerminalBuffer call vebugger#userAction('toggleTerminalBuffer')
 command! -nargs=+ -complete=file VBGtoggleBreakpoint call vebugger#std#toggleBreakpoint(<f-args>)
 command! -nargs=0 VBGtoggleBreakpointThisLine call vebugger#std#toggleBreakpoint(expand('%:~:.'),line('.'))
-command! -nargs=0 VBGclearBreakpints call vebugger#std#clearBreakpoints()
+command! -nargs=0 VBGclearBreakpoints call vebugger#std#clearBreakpoints()
 
 command! -nargs=1 VBGeval call vebugger#userAction('std_eval', <q-args>)
 command! -nargs=0 VBGevalWordUnderCursor call vebugger#userAction('std_eval', expand('<cword>'))
@@ -56,7 +56,7 @@ if exists('g:vebugger_leader')
 					\'c':'VBGcontinue',
 					\'t':'VBGtoggleTerminalBuffer',
 					\'b':'VBGtoggleBreakpointThisLine',
-					\'B':'VBGclearBreakpints',
+					\'B':'VBGclearBreakpoints',
 					\'e':'VBGevalWordUnderCursor',
 					\'E':'exe "VBGeval ".input("VBG-Eval> ")',
 					\'x':'exe "VBGexecute ".getline(".")',


### PR DESCRIPTION
Hey,

I fixed a typo and automatically closed the buffer when killing the debugger. Let me know if that's a good idea or not. (Don't know much about VimL though, so if something is wrong, let me know)!

PS: nice plugin :)

Cheers,

David
