### PR TITLE
Support vim unstack

### DIFF
--- a/autoload/vebugger/lldb.vim
+++ b/autoload/vebugger/lldb.vim
@@ -2,8 +2,13 @@ let s:script_dir_path=expand('<sfile>:p:h')
 
 function! vebugger#lldb#start(binaryFile,args)
 	let l:debuggerExe=vebugger#util#getToolFullPath('python','lldb','python2')
-	let l:debugger=vebugger#std#startDebugger(shellescape(l:debuggerExe)
-				\.' '.s:script_dir_path.'/lldb_wrapper.py '.fnameescape(a:binaryFile))
+    let l:debuggerStartCommand = shellescape(l:debuggerExe)
+				\.' '.s:script_dir_path.'/lldb_wrapper.py '.fnameescape(a:binaryFile)
+    if exists('g:vebugger_copy_stacktrace_to_clipboard_lldb') &&
+                \ g:vebugger_copy_stacktrace_to_clipboard_lldb
+        let l:debuggerStartCommand .= ' --stacktrace_to_clipboard'
+    endif
+	let l:debugger=vebugger#std#startDebugger(l:debuggerStartCommand)
 
 	let l:debugger.state.lldb={}
 

--- a/autoload/vebugger/lldb_wrapper.py
+++ b/autoload/vebugger/lldb_wrapper.py
@@ -78,8 +78,9 @@ class Debugger(object):
             del self._location_to_id[location]
             return breakpoint_id
 
-    def __init__(self, executable):
+    def __init__(self, executable, stacktrace_to_clipboard=False):
         self._executable = executable
+        self._stacktrace_to_clipboard = stacktrace_to_clipboard
         self._debugger = lldb.SBDebugger.Create()
         self._debugger.SetAsync(False)
         self._command_interpreter = self._debugger.GetCommandInterpreter()
@@ -143,6 +144,26 @@ class Debugger(object):
         arguments = parts[1:]
         locals()[command](arguments)
 
+    def _copy_stacktrace_to_clipboard(self, stacktrace):
+        stacktrace_text = '\n'.join('File "{}", line {:d},'.format(file, line) for file, line in reversed(stacktrace))
+        platform_system = platform.system()
+        process = None
+        if platform_system == 'Darwin':
+            process = subprocess.Popen('pbcopy', env={'LANG': 'en_US.UTF-8'}, stdin=subprocess.PIPE)
+        else:
+            # assume we are running on Linux
+            for cmd in (['xclip', '-selection', 'clipboard'], ['xsel', '--clipboard']):
+                try:
+                    process = subprocess.Popen(cmd, stdin=subprocess.PIPE)
+                    break
+                except OSError:
+                    pass
+            else:
+                print(prefix_output('Stacktrace cannot be copied to clipboard! Either install xclip or xsel.',
+                                    'warning: '))
+        if process is not None:
+            process.communicate(stacktrace_text.encode('utf-8'))
+
     @property
     def debugger_output(self):
         if self._last_debugger_return_obj is not None:
@@ -154,7 +175,7 @@ class Debugger(object):
 
     @property
     def where(self):
-        def extract_where(backtrace):
+        def extract_where(backtrace, collect_complete_stacktrace=False):
             where = None
             pattern = re.compile('at:([^:]+):(\d+)')
             backtrace_lines = backtrace.split('\n')
@@ -164,16 +185,25 @@ class Debugger(object):
                     filepath = match_obj.group(1)
                     linenumber = int(match_obj.group(2))
                     if os.access(filepath, os.R_OK):
-                        where = FilePosition(filepath, linenumber)
-                        break
+                        if collect_complete_stacktrace:
+                            if where is None:
+                                where = []
+                            where.append(FilePosition(filepath, linenumber))
+                        else:
+                            where = FilePosition(filepath, linenumber)
+                            break
             return where
 
         where = None
         self.run_command('bt')
         debugger_output = self.debugger_output
         if debugger_output is not None:
-            where = extract_where(debugger_output)
-        return where
+            where = extract_where(debugger_output, self._stacktrace_to_clipboard)
+        if self._stacktrace_to_clipboard and where is not None:
+            self._copy_stacktrace_to_clipboard(where)
+            return where[0]
+        else:
+            return where
 
     @property
     def program_stdout(self):
@@ -223,9 +253,9 @@ def main():
     if len(sys.argv) < 2:
         sys.stderr.write('An executable is needed as an argument.\n')
         sys.exit(1)
-
     executable = sys.argv[1]
-    debugger = Debugger(executable)
+    stacktrace_to_clipboard = (len(sys.argv) > 2 and sys.argv[2] == '--stacktrace_to_clipboard')
+    debugger = Debugger(executable, stacktrace_to_clipboard)
 
     try:
         while True:

--- a/doc/vebugger.txt
+++ b/doc/vebugger.txt
@@ -118,6 +118,18 @@ Example: >
     let g:vebugger_use_tags=1
 <
 
+The LLDB frontend is capable of copying the current debugger stacktrace to
+clipboard in a format that can be read by the vim-unstack plugin (see
+https://github.com/mattboehm/vim-unstack for more information). To activate
+this feature set *g:vebugger_copy_stacktrace_to_clipboard_lldb* option:
+
+Example: >
+    let g:vebugger_copy_stacktrace_to_clipboard_lldb=1
+<
+
+On Linux, you need either xclip or xsel for this feature to work.
+
+
 LAUNCHING DEBUGGERS                                      *vebugger-launching*
 
 A debugger's implementation is responsible for starting it. The standard is to


### PR DESCRIPTION
The LLDB frontend in now capable of copying the current stacktrace to clipboard in a format that is supported by [vim-unstack](https://github.com/mattboehm/vim-unstack). The feature can be activated by setting 
```vim
g:vebugger_copy_stacktrace_to_clipboard_lldb = 1
```
On Linux, either xclip or xsel is needed for the copy operation.