### PR TITLE
Add the ability do enhance the classpath prior to start Debugging

### DIFF
--- a/autoload/vebugger/jdb.vim
+++ b/autoload/vebugger/jdb.vim
@@ -151,25 +151,13 @@ function! vebugger#jdb#_writeFlow(writeAction,debugger)
 	endif
 endfunction
 
-function! s:getClassNameFromFile(filename)
-	let l:className=fnamemodify(a:filename,':t:r') " Get only the name of the file, without path or extension
-	for l:line in readfile(a:filename)
-    " trailing ; is optional to make it work for groovy as well
-		let l:matches=matchlist(l:line,'\vpackage\s+(%(\w|\.)+)\s*;?')
-		if 1<len(l:matches)
-			return l:matches[1].'.'.l:className
-		endif
-	endfor
-	return l:className
-endfunction
-
 function! vebugger#jdb#_writeBreakpoints(writeAction,debugger)
 	for l:breakpoint in a:writeAction
 		let l:class=''
 		if has_key(a:debugger.state.jdb.filesToClassesMap,l:breakpoint.file)
 			let l:class=a:debugger.state.jdb.filesToClassesMap[l:breakpoint.file]
 		else
-			let l:class=s:getClassNameFromFile(l:breakpoint.file)
+			let l:class=vebugger#util#getClassFromFilename(l:breakpoint.file)
 			let a:debugger.state.jdb.filesToClassesMap[l:breakpoint.file]=l:class
 		endif
 

--- a/autoload/vebugger/jdb.vim
+++ b/autoload/vebugger/jdb.vim
@@ -39,7 +39,7 @@ function! vebugger#jdb#start(entryClass,args)
 	call l:debugger.generateWriteActionsFromTemplate()
 
 	call l:debugger.std_addAllBreakpointActions(g:vebugger_breakpoints)
-
+  doautocmd User Vebugger_DebuggerActive
 	return l:debugger
 endfunction
 

--- a/autoload/vebugger/jdb.vim
+++ b/autoload/vebugger/jdb.vim
@@ -1,7 +1,17 @@
 function! vebugger#jdb#start(entryClass,args)
-	let l:debugger=vebugger#std#startDebugger(shellescape(vebugger#util#getToolFullPath('jdb',get(a:args,'version'),'jdb'))
-				\.(has_key(a:args,'classpath') ? ' -classpath '.fnameescape(a:args.classpath) : ''))
+  let l:classpath = (has_key(a:args,'classpath') ? fnameescape(a:args.classpath) : '')
+  let l:jdb_command = shellescape(vebugger#util#getToolFullPath('jdb',get(a:args,'version'),'jdb'))
+
+  doautocmd User Vebugger_PreStartDebugger
+
+  if has_key(g:, 'vebugger_extra_classpath')
+    let l:classpath = l:classpath . ':' . g:vebugger_extra_classpath
+  endif
+
+  let l:debugger=vebugger#std#startDebugger(l:jdb_command . ' -classpath ' . l:classpath)
 	let l:debugger.state.jdb={}
+  let l:debugger.state.jdb.classpath = l:classpath
+
 	if has_key(a:args,'srcpath')
 		let l:debugger.state.jdb.srcpath=a:args.srcpath
 	else

--- a/autoload/vebugger/util.vim
+++ b/autoload/vebugger/util.vim
@@ -1,4 +1,17 @@
 
+
+function! vebugger#util#getClassFromFilename(filename)
+    let l:className=fnamemodify(a:filename,':t:r') " Get only the name of the file, without path or extension
+    for l:line in readfile(a:filename)
+      " trailing ; is optional to make it work for groovy as well
+      let l:matches=matchlist(l:line,'\vpackage\s+(%(\w|\.)+)\s*;?')
+      if 1<len(l:matches)
+        return l:matches[1].'.'.l:className
+      endif
+    endfor
+    return l:className
+endfunction
+
 "Returns the visually selected text
 function! vebugger#util#get_visual_selection()
 	"Shamefully stolen from http://stackoverflow.com/a/6271254/794380


### PR DESCRIPTION
Hello @idanarye !

First, Thanks for this great project!
Here is a Pull Request that implements an idea which I think will ease the use of Vebugger for java. 

The first modification introduces a User autocmd which gives the possibility do append new values to the classpath used by the debugger. This is specially useful when you use a java plugin (such as [vim-javacomplete2](https://github.com/artur-shaik/vim-javacomplete2)) that autiodiscovers the classpath for you. With this sourced file:

```viml
function! InjectExtraClassPath()
  let g:vebugger_extra_classpath = g:JavaComplete_LibsPath
endfunction

augroup VebuggerOptions
  autocmd!
  autocmd User Vebugger_PreStartDebugger call InjectExtraClassPath()
augroup END
```

I'm now able to call the debugger with a simpler (and shorter) line:

```viml
:call vebugger#jdb#start('MyClass', {'srcpath': 'src/main/java'})
```

The second modification exposes a very useful function of the code, which based on a file returns the Java class name.

Now I can have this sourced:
```viml
function! DebugJavaFile()
  return vebugger#jdb#start(vebugger#util#getClassFromFilename(expand('%')), {'srcpath': 'src/main/java'})
endfunction
```

I can Debug the current opened Java file simply caling `DebugJavaFile()`, since I can now discover the classname of the current opened file. This function could be easly hooked to a`<leader>` mapping.

Let me know what do you think about this idea. The names/variables used here are only to demonstrate the idea, if you think this code makes sense to me merged we can adjust anything you feel necessary.

The code is fully functional, I'm already using it do debug java code.

Thanks,  