### PR TITLE
Quick n dirty workaround for pyenv support

### DIFF
--- a/autoload/vebugger/pdb.vim
+++ b/autoload/vebugger/pdb.vim
@@ -1,4 +1,10 @@
 function! vebugger#pdb#start(entryFile,args)
+	let l:pyenv_path=glob('~/.pyenv/versions/'.expand('%:h:t').'/bin/python')
+
+	if !empty(l:pyenv_path)
+		let g:vebugger_path_python=l:pyenv_path
+	endif
+
 	let l:debuggerExe=vebugger#util#getToolFullPath('python',get(a:args,'version'),{
 				\' ':'python',
 				\'2':'python2',


### PR DESCRIPTION
I'm trying to solve my own issue #43.
I added support for pyenv auto-discovery. I don't think though that it's vebugger-ish. You write good, modular code (even though it's VimL 😛) and my solution is just a dirty workaround.

I do not cover non-pyenv virtualenvs, ability to disable the future at all (this can go sideways even for me) and ability to set custom pyenv path.

Do you like it? Should I go on and develop it like it's supposed to?