### PR TITLE
Highlight current executed line (bg=red fg=white)

### DIFF
--- a/autoload/vebugger/std.vim
+++ b/autoload/vebugger/std.vim
@@ -300,7 +300,12 @@ function! s:standardCloseHandlers.removeCurrentMarker(debugger) dict
     sign unplace 1
 endfunction
 
-sign define vebugger_current text=->
+
+if hlexists("DebuggedLine")
+  sign define vebugger_current linehl=DebuggedLine
+else
+  sign define vebugger_current text=->
+endif
 
 if hlexists('BreakPoint')
     sign define vebugger_breakpoint text=** linehl=BreakPoint texthl=BreakPoint


### PR DESCRIPTION
Hi,

this PR changes the way vim-vebugger highlights the current debugged line.

it now hightlitghs thw whole line, instead of adding a `->` sign on the line.


This is how it was berfore this PR:

![screenshot from 2017-10-16 11-56-26](https://user-images.githubusercontent.com/121638/31620169-52e3ae78-b275-11e7-8f9c-d449fe21927c.png)

This is how it is now, after the PR:

![screenshot from 2017-10-16 11-54-49](https://user-images.githubusercontent.com/121638/31620186-5d3b3594-b275-11e7-9806-c21bfc34c486.png)


