### PR TITLE
Add support for multi-srcpath

### DIFF
--- a/autoload/vebugger/jdb.vim
+++ b/autoload/vebugger/jdb.vim
@@ -87,8 +87,7 @@ function! s:findFolderFromStackTrace(src,nameFromStackTrace,frameNumber)
   endif
 
   " If no such tag was found, try to find it using the src path.
-  for l:one_path in vebugger#util#listify(a:src)
-    let l:path=l:one_path
+  for l:path in vebugger#util#listify(a:src)
     for l:dirname in split(a:nameFromStackTrace,'\.')
       let l:nextPath=l:path.'/'.fnameescape(l:dirname)
       if empty(glob(l:nextPath))

--- a/autoload/vebugger/jdb.vim
+++ b/autoload/vebugger/jdb.vim
@@ -87,14 +87,16 @@ function! s:findFolderFromStackTrace(src,nameFromStackTrace,frameNumber)
   endif
 
   " If no such tag was found, try to find it using the src path.
-	let l:path=a:src
-	for l:dirname in split(a:nameFromStackTrace,'\.')
-		let l:nextPath=l:path.'/'.fnameescape(l:dirname)
-		if empty(glob(l:nextPath))
-			return l:path
-		endif
-		let l:path=l:nextPath
-	endfor
+  for l:one_path in split(a:src, ':')
+    let l:path=l:one_path
+    for l:dirname in split(a:nameFromStackTrace,'\.')
+      let l:nextPath=l:path.'/'.fnameescape(l:dirname)
+      if empty(glob(l:nextPath))
+        return l:path
+      endif
+      let l:path=l:nextPath
+    endfor
+  endfor
 	return l:path
 endfunction
 

--- a/autoload/vebugger/jdb.vim
+++ b/autoload/vebugger/jdb.vim
@@ -87,7 +87,7 @@ function! s:findFolderFromStackTrace(src,nameFromStackTrace,frameNumber)
   endif
 
   " If no such tag was found, try to find it using the src path.
-  for l:one_path in split(a:src, ':')
+  for l:one_path in vebugger#util#listify(a:src)
     let l:path=l:one_path
     for l:dirname in split(a:nameFromStackTrace,'\.')
       let l:nextPath=l:path.'/'.fnameescape(l:dirname)

--- a/autoload/vebugger/util.vim
+++ b/autoload/vebugger/util.vim
@@ -115,3 +115,12 @@ function! vebugger#util#isPathAbsolute(path)
 		return a:path[0]=~'\v^[/~$]' "Absolute paths in Linux start with ~(home),/(root dir) or $(environment variable)
 	endif
 endfunction
+
+function! vebugger#util#listify(stringOrList)
+    if type(a:stringOrList) == type([])
+        return copy(a:stringOrList) " so it could safely be modified by map&filter
+    else
+        return [a:stringOrList]
+    endif
+endfunction
+

--- a/doc/vebugger.txt
+++ b/doc/vebugger.txt
@@ -202,7 +202,7 @@ Unlike in the other debuggers, the first argument here is not the name of a
 file - it's the name of the class to run. The supported extra arguments are:
 * "args": Command line arguments for the debugged program
 * "classpath": Where to look for class files
-* "srcpath": Where to look for source files. You can have multiple srcpaths, separated by ':'
+* "srcpath": Where to look for source files. You can have multiple srcpaths, passed as a list
 * "version": The version of the debugger to run
 If you don't supply "classpath" and "srcpath", Vebugger will assume you are
 using the current directory for source files and class files.
@@ -211,7 +211,7 @@ JDB does not have a command for starting it, since you usually want to supply
 "classpath" and "srcpath".
 
 If you need Vebugger to search for the source files in multiple locations, you can
-specify `srcpath` as a ':' separated string. Vebugger will search on all these folders
+specify `srcpath` as a list. Vebugger will search on all these folders
 and the first match will be returned as the Source file to be shown.
 
 

--- a/doc/vebugger.txt
+++ b/doc/vebugger.txt
@@ -202,13 +202,17 @@ Unlike in the other debuggers, the first argument here is not the name of a
 file - it's the name of the class to run. The supported extra arguments are:
 * "args": Command line arguments for the debugged program
 * "classpath": Where to look for class files
-* "srcpath": Where to look for source files
+* "srcpath": Where to look for source files. You can have multiple srcpaths, separated by ':'
 * "version": The version of the debugger to run
 If you don't supply "classpath" and "srcpath", Vebugger will assume you are
 using the current directory for source files and class files.
 
 JDB does not have a command for starting it, since you usually want to supply
 "classpath" and "srcpath".
+
+If you need Vebugger to search for the source files in multiple locations, you can
+specify `srcpath` as a ':' separated string. Vebugger will search on all these folders
+and the first match will be returned as the Source file to be shown.
 
 
 LAUNCHING RDEBUG                                             *vebugger-rdebug*


### PR DESCRIPTION
Now Vebugger can search for a sourcecode in multiple srcpath locations.
The first match is returned and it's the file Vebugger will show.