### PR TITLE
Do not execute autocommands when writing lines to vebugger buffers

### DIFF
--- a/autoload/vebugger.vim
+++ b/autoload/vebugger.vim
@@ -148,7 +148,7 @@ function! s:f_debugger.addLineToTerminal(pipeName,line) dict
     if has_key(self,'terminalBuffer')
         let l:bufwin=bufwinnr(self.terminalBuffer)
         if -1<l:bufwin
-            exe l:bufwin.'wincmd w'
+            exe 'noautocmd '.l:bufwin.'wincmd w'
             if has_key(self,'pipes')
                         \&&has_key(self.pipes,a:pipeName)
                         \&&has_key(self.pipes[a:pipeName],'annotation')
@@ -157,7 +157,7 @@ function! s:f_debugger.addLineToTerminal(pipeName,line) dict
                 call append (line('$'),a:line)
             endif
             normal G
-            wincmd p
+            noautocmd wincmd p
         endif
     endif
 endfunction

--- a/autoload/vebugger/std.vim
+++ b/autoload/vebugger/std.vim
@@ -142,10 +142,10 @@ function! s:standardFunctions.addLineToShellBuffer(line) dict
     if has_key(self,'shellBuffer')
         let l:bufwin=bufwinnr(self.shellBuffer)
         if -1<l:bufwin
-            exe l:bufwin.'wincmd w'
+            exe 'noautocmd '.l:bufwin.'wincmd w'
             call append (line('$'),a:line)
             normal G
-            wincmd p
+            noautocmd wincmd p
         endif
     endif
 endfunction


### PR DESCRIPTION
For writing lines to vebugger's shell and terminal buffer the active
window is changed for every single line which causes a huge slowdown on
large output. By disabling autocommands, these slowdowns can be reduced.