### PR TITLE
Transform filenames to absolute paths when reading debugger locations

### DIFF
--- a/autoload/vebugger/gdb.vim
+++ b/autoload/vebugger/gdb.vim
@@ -128,7 +128,7 @@ function! vebugger#gdb#_readWhere(pipeName,line,readResult,debugger)
 		let l:matches=matchlist(a:line,'\v^\*stopped.*fullname\=\"([^"]+)\",line\=\"(\d+)"')
 		if 2<len(l:matches)
 			let l:file=l:matches[1]
-			let l:file=fnamemodify(l:file,':~:.')
+			let l:file=fnamemodify(l:file,':p')
 			let a:readResult.std.location={
 						\'file':(l:file),
 						\'line':str2nr(l:matches[2])}

--- a/autoload/vebugger/jdb.vim
+++ b/autoload/vebugger/jdb.vim
@@ -116,7 +116,7 @@ function! vebugger#jdb#_readWhere(pipeName,line,readResult,debugger)
 		if 4<len(l:matches)
 			let l:frameNumber=str2nr(l:matches[1])
 			let l:file=s:findFolderFromStackTrace(a:debugger.state.jdb.srcpath,l:matches[2],l:frameNumber).'/'.l:matches[3]
-			let l:file=fnamemodify(l:file,':~:.')
+			let l:file=fnamemodify(l:file,':p')
 			if 1==l:frameNumber " first stackframe is the current location
 				let a:readResult.std.location={
 							\'file':(l:file),

--- a/autoload/vebugger/lldb.vim
+++ b/autoload/vebugger/lldb.vim
@@ -60,7 +60,7 @@ function! vebugger#lldb#_readWhere(pipeName,line,readResult,debugger)
 		let l:matches=matchlist(a:line,'\v^where:\s([^:]+):(\d+)')
 		if 2<len(l:matches)
 			let l:file=l:matches[1]
-			let l:file=fnamemodify(l:file,':~:.')
+			let l:file=fnamemodify(l:file,':p')
 			let a:readResult.std.location={
 						\'file':(l:file),
 						\'line':str2nr(l:matches[2])}

--- a/autoload/vebugger/mdbg.vim
+++ b/autoload/vebugger/mdbg.vim
@@ -95,7 +95,7 @@ function! vebugger#mdbg#_readWhere(pipeName,line,readResult,debugger)
 	if 3<len(l:matches)
 	    let l:frameNumber=str2nr(l:matches[1])
 	    let l:file=s:findFilePath(a:debugger.state.mdbg.srcpath,l:matches[3],l:matches[2])
-	    let l:file=fnamemodify(l:file,':~:.')
+	    let l:file=fnamemodify(l:file,':p')
 	    if 0==l:frameNumber " first stackframe is the current location
 		let a:readResult.std.location={
 			    \'file':(l:file),


### PR DESCRIPTION
Before this commit, many debugger `where` functions transformed the
filename of the current debugger location to a path relative to vim's
current working directory. When the user changed the current working
directory in the meantime, the previously saved location could not
resolved any more and lead to errors. This commit fixes this problem by
storing absolute paths instead.