### PR TITLE
Fixed windows path problem

### DIFF
--- a/autoload/vebugger/gdb.vim
+++ b/autoload/vebugger/gdb.vim
@@ -127,7 +127,7 @@ function! vebugger#gdb#_readWhere(pipeName,line,readResult,debugger)
 	if 'out'==a:pipeName
 		let l:matches=matchlist(a:line,'\v^\*stopped.*fullname\=\"([^"]+)\",line\=\"(\d+)"')
 		if 2<len(l:matches)
-			let l:file=l:matches[1]
+			let l:file=has('win32') ? substitute(l:matches[1], '\\\\', '\\', 'g') : l:matches[1]
 			let l:file=fnamemodify(l:file,':p')
 			let a:readResult.std.location={
 						\'file':(l:file),


### PR DESCRIPTION
In windows, backslash is doubled in l:matches[1]  (for example, c:\\\\example\\\\example.cpp).
I fixed it.
