### PR TITLE
Fixed shellslash problems in windows

### DIFF
--- a/autoload/vebugger/gdb.vim
+++ b/autoload/vebugger/gdb.vim
@@ -127,7 +127,7 @@ function! vebugger#gdb#_readWhere(pipeName,line,readResult,debugger)
 	if 'out'==a:pipeName
 		let l:matches=matchlist(a:line,'\v^\*stopped.*fullname\=\"([^"]+)\",line\=\"(\d+)"')
 		if 2<len(l:matches)
-			let l:file=has('win32') ? substitute(l:matches[1], '\\\\', '\\', 'g') : l:matches[1]
+			let l:file=has('win32') ? &shellslash ? substitute(l:matches[1], '\\\\', '/', 'g') : substitute(l:matches[1], '\\\\', '\\', 'g') : l:matches[1]
 			let l:file=fnamemodify(l:file,':p')
 			let a:readResult.std.location={
 						\'file':(l:file),

--- a/autoload/vebugger/pdb.vim
+++ b/autoload/vebugger/pdb.vim
@@ -59,7 +59,7 @@ function! vebugger#pdb#_readWhere(pipeName,line,readResult,debugger)
 		let l:matches=matchlist(a:line,'\v^\> (.+)\((\d+)\).*\(\)%(-\>.*)?$')
 
 		if 2<len(l:matches)
-			let l:file=l:matches[1]
+			let l:file=has('win32') && &shellslash ? substitute(l:matches[1], '\\', '/', 'g') : l:matches[1]
 			if !empty(glob(l:file))
 				let l:line=str2nr(l:matches[2])
 				let a:readResult.std.location={


### PR DESCRIPTION
In windows, expand('%:p') normally returns 'c:\example\example'.
But it returns 'c:/example/example' if an user used 'set shellsslash'.
It caused problems on following codes.
                if fnamemodify(a:state.std.location.file,':p')==fnamemodify(a:filename,':p')

I fixed only gdb and pdb.
Other debuggers may have same problem, but I didn't check those because I didn't have.