### PR TITLE
Fix variant for remove/clear breakpoint(s) issue (Issue #81)

### DIFF
--- a/autoload/vebugger/std.vim
+++ b/autoload/vebugger/std.vim
@@ -323,7 +323,10 @@ function! vebugger#std#updateMarksForFile(state,filename)
     if -1 < l:bufnr
         exe 'sign unplace 1 file='.fnamemodify(l:filename,':p')
         for l:sign in vebugger#util#listSignsInBuffer(l:bufnr)
-            if l:sign.name == 'vebugger_breakpoint'
+            " Checking that sign name starts with 'vebugger_breakpoint'
+            " instead of assuming exact equality
+            let l:is_breakpoint=match(l:sign.name, '^vebugger_breakpoint')
+            if l:is_breakpoint == 0
                 exe 'sign unplace 2 file='.fnamemodify(l:filename,':p')
             endif
         endfor


### PR DESCRIPTION
#81 
This is my attempt on fixing it. It works for me. Tested with GDB by adding/removing separate breakpoints by toggling with \b and clearing all breakpoints by \B. I'm not sure if it will be long term fix, as it looks like you changed breakpoint sign structure and that broke removal code, so may be you'll need to adjust it further.