### PR TITLE
add a configuration option vebugger_ignore_patterns

### DIFF
--- a/autoload/vebugger.vim
+++ b/autoload/vebugger.vim
@@ -75,6 +75,7 @@ function! s:f_debugger.handleLine(pipeName,line) dict
         for pattern in l:ignore_patterns
             if match(a:line, pattern) >= 0
                 let l:ignore_the_line = 1
+                break
             endif
         endfor
         if !l:ignore_the_line

--- a/autoload/vebugger.vim
+++ b/autoload/vebugger.vim
@@ -63,7 +63,26 @@ endfunction
 
 "Handle a single line from the debugger's interactive shell
 function! s:f_debugger.handleLine(pipeName,line) dict
-    call self.addLineToTerminal(a:pipeName,a:line)
+    let l:ignore_patterns = []
+    if exists('b:vebugger_ignore_patterns')
+        let l:ignore_patterns = b:vebugger_ignore_patterns
+    elseif exists('g:vebugger_ignore_patterns')
+        let l:ignore_patterns = g:vebugger_ignore_patterns
+    endif
+
+    if len(l:ignore_patterns)
+        let l:ignore_the_line = 0
+        for pattern in l:ignore_patterns
+            if match(a:line, pattern) >= 0
+                let l:ignore_the_line = 1
+            endif
+        endfor
+        if !l:ignore_the_line
+            call self.addLineToTerminal(a:pipeName,a:line)
+        endif
+    else
+        call self.addLineToTerminal(a:pipeName,a:line)
+    endif
 
     let l:readResult=deepcopy(self.readResultTemplate,1)
 

--- a/doc/vebugger.txt
+++ b/doc/vebugger.txt
@@ -129,7 +129,7 @@ Example: >
 <
 
 If you want to prevent Vebugger from writing messages in a specific pattern
-on a terminal buffer opened by using *:VBGtoggleTerminalBuffer* command, you
+on a terminal buffer opened by using |:VBGtoggleTerminalBuffer| command, you
 can use a vim regex pattern in the option *g:vebugger_ignore_patterns* or
 *b:vebugger_ignore_patterns*
 

--- a/doc/vebugger.txt
+++ b/doc/vebugger.txt
@@ -128,7 +128,7 @@ Example: >
     let g:vebugger_use_tags=1
 <
 
-If you want to prevent Vebugger from writing specific text in a specific
+If you want to prevent Vebugger from writing messages in a specific
 pattern, you can use a vim regex pattern by setting the option
 *g:vebugger_ignore_patterns* or *b:vebugger_ignore_patterns*
 

--- a/doc/vebugger.txt
+++ b/doc/vebugger.txt
@@ -129,7 +129,7 @@ Example: >
 <
 
 If you want to prevent Vebugger from writing specific text in a specific
-pattern, you can use a vim regex pattern to do so by setting the option
+pattern, you can use a vim regex pattern by setting the option
 *g:vebugger_ignore_patterns* or *b:vebugger_ignore_patterns*
 
 Example: >

--- a/doc/vebugger.txt
+++ b/doc/vebugger.txt
@@ -128,6 +128,21 @@ Example: >
     let g:vebugger_use_tags=1
 <
 
+If you want to prevent Vebugger from writing specific text in a specific
+pattern, you can use a vim regex pattern to do so by setting the option
+*g:vebugger_ignore_patterns* or *b:vebugger_ignore_patterns*
+
+Example: >
+    let g:vebugger_ignore_patterns = [
+      \ '^*stopped',
+      \ '^[*^]running',
+      \ 'next$',
+      \ '^&\?display',
+      \ '^&\?continue',
+      \ '\^done$',
+      \ ]
+<
+
 LAUNCHING DEBUGGERS                                      *vebugger-launching*
 
 A debugger's implementation is responsible for starting it. The standard is to

--- a/doc/vebugger.txt
+++ b/doc/vebugger.txt
@@ -128,9 +128,10 @@ Example: >
     let g:vebugger_use_tags=1
 <
 
-If you want to prevent Vebugger from writing messages in a specific
-pattern, you can use a vim regex pattern by setting the option
-*g:vebugger_ignore_patterns* or *b:vebugger_ignore_patterns*
+If you want to prevent Vebugger from writing messages in a specific pattern
+on a terminal buffer opened by using *:VBGtoggleTerminalBuffer* command, you
+can use a vim regex pattern in the option *g:vebugger_ignore_patterns* or
+*b:vebugger_ignore_patterns*
 
 Example: >
     let g:vebugger_ignore_patterns = [


### PR DESCRIPTION
Signed-off-by: Gunwoo Gim (The obtuse) <wind8702@gmail.com>

It implements a simple feature that allows you to filter out some messages from the debuggers using vim regular expression function.