### PR TITLE
Added conditional breakpoints

### DIFF
--- a/autoload/vebugger/gdb.vim
+++ b/autoload/vebugger/gdb.vim
@@ -162,7 +162,7 @@ endfunction
 function! vebugger#gdb#_writeBreakpoints(writeAction,debugger)
 	for l:breakpoint in a:writeAction
 		if 'add'==(l:breakpoint.action)
-			call a:debugger.writeLine('break '.fnameescape(l:breakpoint.file).':'.l:breakpoint.line)
+			call a:debugger.writeLine('break '.fnameescape(l:breakpoint.file).':'.l:breakpoint.line.' '.l:breakpoint.condition)
 		elseif 'remove'==l:breakpoint.action
 			call a:debugger.writeLine('clear '.fnameescape(l:breakpoint.file).':'.l:breakpoint.line)
 		endif

--- a/autoload/vebugger/std.vim
+++ b/autoload/vebugger/std.vim
@@ -156,7 +156,8 @@ function! s:standardFunctions.addAllBreakpointActions(breakpoints) dict
         call self.addWriteAction('std','breakpoints',{
                     \'action':'add',
                     \'file':(l:breakpoint.file),
-                    \'line':(l:breakpoint.line)})
+                    \'line':(l:breakpoint.line),
+                    \'condition':(l:breakpoint.condition)})
     endfor
 endfunction
 
@@ -347,8 +348,12 @@ function! vebugger#std#updateMarksForFile(state,filename)
     endif
 endfunction
 
-"Toggle a breakpoint on and off
 function! vebugger#std#toggleBreakpoint(file,line)
+  call vebugger#std#toggleConditionalBreakpoint(a:file,a:line,"")
+endfunction
+
+"Toggle a breakpoint on and off
+function! vebugger#std#toggleConditionalBreakpoint(file,line,condition)
     let l:debugger=vebugger#getActiveDebugger()
     let l:debuggerState=empty(l:debugger)
                 \? {}
@@ -367,12 +372,13 @@ function! vebugger#std#toggleBreakpoint(file,line)
             return
         endif
     endfor
-    call add(g:vebugger_breakpoints,{'file':(a:file),'line':(a:line)})
+    call add(g:vebugger_breakpoints,{'file':(a:file),'line':(a:line),'condition':(a:condition)})
     if !empty(l:debugger)
         call l:debugger.addWriteActionAndPerform('std','breakpoints',{
                     \'action':'add',
                     \'file':(a:file),
-                    \'line':(a:line)})
+                    \'line':(a:line),
+                    \'condition':(a:condition)})
     endif
     call vebugger#std#updateMarksForFile(l:debuggerState,a:file)
 endfunction

--- a/plugin/vebugger.vim
+++ b/plugin/vebugger.vim
@@ -13,6 +13,7 @@ command! -nargs=0 VBGcontinue call vebugger#userAction('setWriteActionAndPerform
 command! -nargs=0 VBGtoggleTerminalBuffer call vebugger#userAction('toggleTerminalBuffer')
 command! -nargs=+ -complete=file VBGtoggleBreakpoint call vebugger#std#toggleBreakpoint(<f-args>)
 command! -nargs=0 VBGtoggleBreakpointThisLine call vebugger#std#toggleBreakpoint(expand('%:p:.'),line('.'))
+command! -nargs=1 VBGaddConditionalBreakpointThisLine call vebugger#std#toggleConditionalBreakpoint(expand('%:p:.'),line('.'), <q-args>)
 command! -nargs=0 VBGclearBreakpoints call vebugger#std#clearBreakpoints()
 
 command! -nargs=1 VBGeval call vebugger#userAction('std_eval', <q-args>)
@@ -72,6 +73,7 @@ if exists('g:vebugger_leader')
 					\'i':'VBGstepIn',
 					\'o':'VBGstepOver',
 					\'O':'VBGstepOut',
+					\'k':'exe "VBGaddConditionalBreakpointThisLine ".input("Condition> ")',
 					\'c':'VBGcontinue',
 					\'t':'VBGtoggleTerminalBuffer',
 					\'b':'VBGtoggleBreakpointThisLine',


### PR DESCRIPTION
Added support for conditional breakpoints for gdb. To test this; I used the following fizzbuzz in C++:

```
#include<iostream>
using std::cout;
using std::endl;

void print_fizzbuzz(int n) {
  const bool mod5 = n % 5 == 0;
  const bool mod3 = n % 3 == 0;
  if (mod3 && mod5) {
    cout << "FizzBuzz" << endl;
  } else if (mod3) {
    cout << "Fizz" << endl;
  } else if (mod5) {
    cout << "Buzz" << endl;
  } else {
    cout << n << endl;
  }
}

void fizzbuzz() {
  for (int i = 1; i <= 100; ++i) {
    print_fizzbuzz(i);
  }
}

int main() {
  fizzbuzz();
  return 0;
}
```

Using this branch, I can add a breakpoint for instance on line 6 with `<vebugger-leader>k` and then type in `if n == 5`. Everything I tested works:
- Setting the breakpoint before or after the debugger has started
- Toggling the breakpoint with or without a condition works; when removing, the condition passed in is ignored. The highlight correctly updates when you add conditional breakpoints, although you can't see the difference between a conditional breakpoint and a regular one.
- Toggling normal breakpoints still works, because the empty string is passed as the condition, which will just add a space at the end of the command passed to the debugger, which it ignores.

Note: I have not yet tested other debuggers than gdb. Presumably we should add it for others that support it as well.

Adding support for #95 was easier than I thought!